### PR TITLE
Make AdminFlags mutable

### DIFF
--- a/RedProtect-Core/src/main/java/br/net/fabiozumbi12/RedProtect/Core/config/CoreConfigManager.java
+++ b/RedProtect-Core/src/main/java/br/net/fabiozumbi12/RedProtect/Core/config/CoreConfigManager.java
@@ -44,7 +44,7 @@ import static com.google.common.reflect.TypeToken.of;
 
 public class CoreConfigManager {
 
-    public final List<String> AdminFlags = Arrays.asList(
+    public final List<String> AdminFlags = new ArrayList<>(Arrays.asList(
             "spawn-wither",
             "cropsfarm",
             "keep-inventory",
@@ -93,7 +93,7 @@ public class CoreConfigManager {
             "deny-exit-items",
             "spawn-animals",
             "spawn-monsters",
-            "can-move");
+            "can-move"));
     public HashMap<String, String> backupGuiName = new HashMap<>();
     public HashMap<String, String> backupGuiDescription = new HashMap<>();
     protected String headerCfg = ""


### PR DESCRIPTION
I think this may fix the UnsupportedOperationException referenced in #672 

However, I don't have all of the necessary dependencies (mostly the Sponge stuff I think) to build the plugin, so I'm honestly not sure if there will be other issues with adding custom admin flags.