### PR TITLE
Change AdminFlags in CoreConfigManager to static

### DIFF
--- a/RedProtect-Core/src/main/java/br/net/fabiozumbi12/RedProtect/Core/config/CoreConfigManager.java
+++ b/RedProtect-Core/src/main/java/br/net/fabiozumbi12/RedProtect/Core/config/CoreConfigManager.java
@@ -44,7 +44,7 @@ import static com.google.common.reflect.TypeToken.of;
 
 public class CoreConfigManager {
 
-    public final List<String> AdminFlags = new ArrayList<>(Arrays.asList(
+    public final static List<String> ADMIN_FLAGS = new ArrayList<>(Arrays.asList(
             "spawn-wither",
             "cropsfarm",
             "keep-inventory",
@@ -257,8 +257,8 @@ public class CoreConfigManager {
 
     public boolean addFlag(String flag, boolean defaultValue, boolean isAdmin) {
         if (isAdmin) {
-            if (!AdminFlags.contains(flag)) {
-                AdminFlags.add(flag);
+            if (!ADMIN_FLAGS.contains(flag)) {
+                ADMIN_FLAGS.add(flag);
                 return true;
             }
         } else {
@@ -273,7 +273,7 @@ public class CoreConfigManager {
 
     public boolean removeFlag(String flag, boolean isAdmin) {
         if (isAdmin) {
-            return AdminFlags.remove(flag);
+            return ADMIN_FLAGS.remove(flag);
         } else {
             return root.flags.remove(flag) != null;
         }

--- a/RedProtect-Sponge-56/src/main/java/br/net/fabiozumbi12/RedProtect/Sponge/API/RedProtectAPI.java
+++ b/RedProtect-Sponge-56/src/main/java/br/net/fabiozumbi12/RedProtect/Sponge/API/RedProtectAPI.java
@@ -251,7 +251,7 @@ public class RedProtectAPI {
      * @param flag Admin Flag to add
      */
     public void addAdminFlag(String flag) {
-        RedProtect.get().getConfigManager().AdminFlags.add(flag);
+        RedProtect.get().getConfigManager().ADMIN_FLAGS.add(flag);
     }
 
     /**

--- a/RedProtect-Sponge-56/src/main/java/br/net/fabiozumbi12/RedProtect/Sponge/Region.java
+++ b/RedProtect-Sponge-56/src/main/java/br/net/fabiozumbi12/RedProtect/Sponge/Region.java
@@ -628,7 +628,7 @@ public class Region extends CoreRegion {
                 continue;
             }
 
-            if (RedProtect.get().getConfigManager().AdminFlags.contains(flag)) {
+            if (RedProtect.get().getConfigManager().ADMIN_FLAGS.contains(flag)) {
                 String flagValue = this.flags.get(flag).toString();
                 if (flagValue.equalsIgnoreCase("true") || flagValue.equalsIgnoreCase("false")) {
                     flaginfo.append(", &b").append(flag).append(": ").append(RedProtect.get().getLanguageManager().translBool(flagValue));

--- a/RedProtect-Sponge-56/src/main/java/br/net/fabiozumbi12/RedProtect/Sponge/commands/CommandHandlers.java
+++ b/RedProtect-Sponge-56/src/main/java/br/net/fabiozumbi12/RedProtect/Sponge/commands/CommandHandlers.java
@@ -729,7 +729,7 @@ public class CommandHandlers {
 
         Object objflag = RedProtect.get().getUtil().parseObject(value);
 
-        if ((RedProtect.get().getPermissionHandler().hasFlagPerm(p, flag) && (RedProtect.get().getConfigManager().configRoot().flags.containsKey(flag) || RedProtect.get().getConfigManager().AdminFlags.contains(flag))) || flag.equalsIgnoreCase("info")) {
+        if ((RedProtect.get().getPermissionHandler().hasFlagPerm(p, flag) && (RedProtect.get().getConfigManager().configRoot().flags.containsKey(flag) || RedProtect.get().getConfigManager().ADMIN_FLAGS.contains(flag))) || flag.equalsIgnoreCase("info")) {
             if (r.isAdmin(p) || r.isLeader(p) || RedProtect.get().getPermissionHandler().hasPerm(p, "redprotect.command.admin.flag")) {
                 if (checkCmd(flag, "info")) {
                     p.sendMessage(RedProtect.get().getUtil().toText(RedProtect.get().getLanguageManager().get("general.color") + "------------[" + RedProtect.get().getLanguageManager().get("cmdmanager.region.flag.values") + "]------------"));
@@ -739,7 +739,7 @@ public class CommandHandlers {
                 }
 
                 if (value.equalsIgnoreCase("remove")) {
-                    if (RedProtect.get().getConfigManager().AdminFlags.contains(flag) && r.getFlags().containsKey(flag)) {
+                    if (RedProtect.get().getConfigManager().ADMIN_FLAGS.contains(flag) && r.getFlags().containsKey(flag)) {
                         r.removeFlag(flag);
                         RedProtect.get().getLanguageManager().sendMessage(p, RedProtect.get().getLanguageManager().get("cmdmanager.region.flag.removed").replace("{flag}", flag).replace("{region}", r.getName()));
                         RedProtect.get().logger.addLog("(World " + r.getWorld() + ") Player " + p.getName() + " REMOVED FLAG " + flag + " of region " + r.getName());
@@ -764,7 +764,7 @@ public class CommandHandlers {
                         }
                     }
 
-                    if (RedProtect.get().getConfigManager().AdminFlags.contains(flag)) {
+                    if (RedProtect.get().getConfigManager().ADMIN_FLAGS.contains(flag)) {
                         if (!validate(flag, objflag)) {
                             SendFlagUsageMessage(p, flag);
                             return;
@@ -796,7 +796,7 @@ public class CommandHandlers {
                             RedProtect.get().logger.addLog("(World " + r.getWorld() + ") Player " + p.getName() + " SET FLAG " + flag + " of region " + r.getName() + " to " + r.getFlagString(flag));
                         }
                     } else {
-                        if (RedProtect.get().getConfigManager().AdminFlags.contains(flag)) {
+                        if (RedProtect.get().getConfigManager().ADMIN_FLAGS.contains(flag)) {
                             SendFlagUsageMessage(p, flag);
                         } else {
                             RedProtect.get().getLanguageManager().sendMessage(p, RedProtect.get().getLanguageManager().get("cmdmanager.region.flag.usage") + " <true/false>");
@@ -842,7 +842,7 @@ public class CommandHandlers {
         p.sendMessage(RedProtect.get().getUtil().toText(RedProtect.get().getLanguageManager().get("general.color") + "------------------------------------"));
 
         StringBuilder sb = new StringBuilder();
-        for (String flag : RedProtect.get().getConfigManager().AdminFlags) {
+        for (String flag : RedProtect.get().getConfigManager().ADMIN_FLAGS) {
             if (RedProtect.get().getPermissionHandler().hasFlagPerm(p, flag))
                 sb.append(flag).append(", ");
         }

--- a/RedProtect-Sponge-56/src/main/java/br/net/fabiozumbi12/RedProtect/Sponge/commands/SubCommands/RegionHandlers/FlagCommand.java
+++ b/RedProtect-Sponge-56/src/main/java/br/net/fabiozumbi12/RedProtect/Sponge/commands/SubCommands/RegionHandlers/FlagCommand.java
@@ -159,7 +159,7 @@ class FlagCommandElement extends CommandElement {
         String[] args = argss.getRaw().split(" ");
         if (args.length == 1) {
             SortedSet<String> tab = new TreeSet<>(RedProtect.get().getConfigManager().getDefFlags());
-            for (String flag : RedProtect.get().getConfigManager().AdminFlags) {
+            for (String flag : RedProtect.get().getConfigManager().ADMIN_FLAGS) {
                 if (RedProtect.get().getPermissionHandler().hasFlagPerm((Player) sender, flag)) {
                     tab.add(flag);
                 }
@@ -173,7 +173,7 @@ class FlagCommandElement extends CommandElement {
                     tab.add(flag);
                 }
             }
-            for (String flag : RedProtect.get().getConfigManager().AdminFlags) {
+            for (String flag : RedProtect.get().getConfigManager().ADMIN_FLAGS) {
                 if (flag.startsWith(args[1]) && RedProtect.get().getPermissionHandler().hasFlagPerm((Player) sender, flag)) {
                     tab.add(flag);
                 }

--- a/RedProtect-Sponge-56/src/main/java/br/net/fabiozumbi12/RedProtect/Sponge/database/WorldFlatFileRegionManager.java
+++ b/RedProtect-Sponge-56/src/main/java/br/net/fabiozumbi12/RedProtect/Sponge/database/WorldFlatFileRegionManager.java
@@ -130,7 +130,7 @@ public class WorldFlatFileRegionManager implements WorldRegionManager {
                     newr.getFlags().put(flag, RedProtect.get().getConfigManager().getDefFlagsValues().get(flag));
                 }
             }
-            for (String flag : RedProtect.get().getConfigManager().AdminFlags) {
+            for (String flag : RedProtect.get().getConfigManager().ADMIN_FLAGS) {
                 if (region.getNode(rname, "flags", flag).getString() != null) {
                     newr.getFlags().put(flag, region.getNode(rname, "flags", flag).getValue());
                 }

--- a/RedProtect-Sponge-56/src/main/java/br/net/fabiozumbi12/RedProtect/Sponge/database/WorldFlatFileRegionManager.java
+++ b/RedProtect-Sponge-56/src/main/java/br/net/fabiozumbi12/RedProtect/Sponge/database/WorldFlatFileRegionManager.java
@@ -26,11 +26,13 @@
 
 package br.net.fabiozumbi12.RedProtect.Sponge.database;
 
+import br.net.fabiozumbi12.RedProtect.Core.config.CoreConfigManager;
 import br.net.fabiozumbi12.RedProtect.Core.helpers.CoreUtil;
 import br.net.fabiozumbi12.RedProtect.Core.helpers.LogLevel;
 import br.net.fabiozumbi12.RedProtect.Core.region.PlayerRegion;
 import br.net.fabiozumbi12.RedProtect.Sponge.RedProtect;
 import br.net.fabiozumbi12.RedProtect.Sponge.Region;
+import br.net.fabiozumbi12.RedProtect.Sponge.helpers.RedProtectLogger;
 import com.google.common.reflect.TypeToken;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
@@ -130,7 +132,18 @@ public class WorldFlatFileRegionManager implements WorldRegionManager {
                     newr.getFlags().put(flag, RedProtect.get().getConfigManager().getDefFlagsValues().get(flag));
                 }
             }
-            for (String flag : RedProtect.get().getConfigManager().ADMIN_FLAGS) {
+
+            // Next loop adds to ADMIN_FLAGS list all flags from config node except default ones
+            // this prevents admin flags from being erased after server restart
+            for(Object o : region.getNode(rname, "flags").getChildrenMap().keySet().stream()
+                    .filter(o -> !RedProtect.get().getConfigManager().getDefFlags().contains(o.toString()))
+                    .filter(o -> !CoreConfigManager.ADMIN_FLAGS.contains(o.toString()))
+                    .toArray()) {
+                RedProtect.get().logger.warning("Admin flag: " + o.toString());
+                CoreConfigManager.ADMIN_FLAGS.add(o.toString());
+            }
+
+            for (String flag : CoreConfigManager.ADMIN_FLAGS) {
                 if (region.getNode(rname, "flags", flag).getString() != null) {
                     newr.getFlags().put(flag, region.getNode(rname, "flags", flag).getValue());
                 }

--- a/RedProtect-Sponge-56/src/main/java/br/net/fabiozumbi12/RedProtect/Sponge/guis/FlagGui.java
+++ b/RedProtect-Sponge-56/src/main/java/br/net/fabiozumbi12/RedProtect/Sponge/guis/FlagGui.java
@@ -88,7 +88,7 @@ public class FlagGui {
                 if (!(region.getFlags().get(flag) instanceof Boolean) || !RedProtect.get().getConfigManager().guiRoot().gui_flags.containsKey(flag)) {
                     continue;
                 }
-                if (RedProtect.get().getPermissionHandler().hasFlagPerm(player, flag) && (RedProtect.get().getConfigManager().configRoot().flags.containsKey(flag) || RedProtect.get().getConfigManager().AdminFlags.contains(flag))) {
+                if (RedProtect.get().getPermissionHandler().hasFlagPerm(player, flag) && (RedProtect.get().getConfigManager().configRoot().flags.containsKey(flag) || RedProtect.get().getConfigManager().ADMIN_FLAGS.contains(flag))) {
                     if (flag.equals("pvp") && !RedProtect.get().getConfigManager().configRoot().flags.containsKey("pvp")) {
                         continue;
                     }

--- a/RedProtect-Sponge-56/src/main/java/br/net/fabiozumbi12/RedProtect/Sponge/listeners/BlockListener.java
+++ b/RedProtect-Sponge-56/src/main/java/br/net/fabiozumbi12/RedProtect/Sponge/listeners/BlockListener.java
@@ -180,7 +180,7 @@ public class BlockListener {
                     RedProtect.get().getVersionHelper().digBlock(p, b.getPosition());
                     return;
                 }
-                if (RedProtect.get().getPermissionHandler().hasFlagPerm(p, flag) && (RedProtect.get().getConfigManager().configRoot().flags.containsKey(flag) || RedProtect.get().getConfigManager().AdminFlags.contains(flag))) {
+                if (RedProtect.get().getPermissionHandler().hasFlagPerm(p, flag) && (RedProtect.get().getConfigManager().configRoot().flags.containsKey(flag) || RedProtect.get().getConfigManager().ADMIN_FLAGS.contains(flag))) {
                     if (signr.isAdmin(p) || signr.isLeader(p) || RedProtect.get().getPermissionHandler().hasPerm(p, "redprotect.admin.flag." + flag)) {
                         lines.set(1, RedProtect.get().getUtil().toText(flag));
                         lines.set(2, RedProtect.get().getUtil().toText("&3&l" + signr.getName()));

--- a/RedProtect-Sponge-56/src/main/java/br/net/fabiozumbi12/RedProtect/Sponge/listeners/PlayerListener.java
+++ b/RedProtect-Sponge-56/src/main/java/br/net/fabiozumbi12/RedProtect/Sponge/listeners/PlayerListener.java
@@ -356,7 +356,7 @@ public class PlayerListener {
                         RedProtect.get().getLanguageManager().sendMessage(p, RedProtect.get().getLanguageManager().get("playerlistener.region.sign.cantflag"));
                         return;
                     }
-                    if (RedProtect.get().getPermissionHandler().hasFlagPerm(p, flag) && (RedProtect.get().getConfigManager().configRoot().flags.containsKey(flag) || RedProtect.get().getConfigManager().AdminFlags.contains(flag))) {
+                    if (RedProtect.get().getPermissionHandler().hasFlagPerm(p, flag) && (RedProtect.get().getConfigManager().configRoot().flags.containsKey(flag) || RedProtect.get().getConfigManager().ADMIN_FLAGS.contains(flag))) {
                         if (r.isAdmin(p) || r.isLeader(p) || RedProtect.get().getPermissionHandler().hasPerm(p, "redprotect.admin.flag." + flag)) {
                             if (RedProtect.get().getConfigManager().configRoot().flags_configuration.change_flag_delay.enable) {
                                 if (RedProtect.get().getConfigManager().configRoot().flags_configuration.change_flag_delay.flags.contains(flag)) {
@@ -427,7 +427,7 @@ public class PlayerListener {
                         RedProtect.get().getLanguageManager().sendMessage(p, RedProtect.get().getLanguageManager().get("playerlistener.region.sign.cantflag"));
                         return;
                     }
-                    if (RedProtect.get().getPermissionHandler().hasFlagPerm(p, flag) && (RedProtect.get().getConfigManager().configRoot().flags.containsKey(flag) || RedProtect.get().getConfigManager().AdminFlags.contains(flag))) {
+                    if (RedProtect.get().getPermissionHandler().hasFlagPerm(p, flag) && (RedProtect.get().getConfigManager().configRoot().flags.containsKey(flag) || RedProtect.get().getConfigManager().ADMIN_FLAGS.contains(flag))) {
                         if (r.isAdmin(p) || r.isLeader(p) || RedProtect.get().getPermissionHandler().hasPerm(p, "redprotect.admin.flag." + flag)) {
                             if (RedProtect.get().getConfigManager().configRoot().flags_configuration.change_flag_delay.enable) {
                                 if (RedProtect.get().getConfigManager().configRoot().flags_configuration.change_flag_delay.flags.contains(flag)) {


### PR DESCRIPTION
This PR provides a solution for #716 
AdminFlags changed to static as it's should not be redefined on every creation of new class instance.
Alse name changed to ADMIN_FLAGS due to "static final" naming convention