### PR TITLE
Teleport immediately if delay is less than one second

### DIFF
--- a/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/commands/CommandHandlers.java
+++ b/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/commands/CommandHandlers.java
@@ -567,6 +567,15 @@ public class CommandHandlers {
             p.teleport(loc);
             return;
         }
+
+        int delay = RedProtect.get().getConfigManager().configRoot().region_settings.teleport_time;
+
+        if(delay < 1) {
+            p.teleport(loc);
+            RedProtect.get().getLanguageManager().sendMessage(p, RedProtect.get().getLanguageManager().get("cmdmanager.region.teleport") + " " + rname);
+            return;
+        }
+
         if (!RedProtect.get().tpWait.contains(p.getName())) {
             RedProtect.get().tpWait.add(p.getName());
             RedProtect.get().getLanguageManager().sendMessage(p, "cmdmanager.region.tpdontmove");
@@ -579,7 +588,7 @@ public class CommandHandlers {
                     p.teleport(loc);
                     RedProtect.get().getLanguageManager().sendMessage(p, RedProtect.get().getLanguageManager().get("cmdmanager.region.teleport") + " " + rname);
                 }
-            }, RedProtect.get().getConfigManager().configRoot().region_settings.teleport_time * 20);
+            }, delay * 20L);
         } else {
             RedProtect.get().getLanguageManager().sendMessage(p, "cmdmanager.region.tpneedwait");
         }

--- a/RedProtect-Sponge-56/src/main/java/br/net/fabiozumbi12/RedProtect/Sponge/commands/CommandHandlers.java
+++ b/RedProtect-Sponge-56/src/main/java/br/net/fabiozumbi12/RedProtect/Sponge/commands/CommandHandlers.java
@@ -572,6 +572,15 @@ public class CommandHandlers {
             p.setLocation(loc);
             return;
         }
+
+        int delay = RedProtect.get().getConfigManager().configRoot().region_settings.teleport_time;
+
+        if(delay < 1) {
+            p.setLocation(loc);
+            RedProtect.get().getLanguageManager().sendMessage(p, RedProtect.get().getLanguageManager().get("cmdmanager.region.teleport") + " " + rname);
+            return;
+        }
+
         if (!RedProtect.get().tpWait.contains(p.getName())) {
             RedProtect.get().tpWait.add(p.getName());
             RedProtect.get().getLanguageManager().sendMessage(p, "cmdmanager.region.tpdontmove");
@@ -581,7 +590,7 @@ public class CommandHandlers {
                     p.setLocation(loc);
                     RedProtect.get().getLanguageManager().sendMessage(p, RedProtect.get().getLanguageManager().get("cmdmanager.region.teleport") + " " + rname);
                 }
-            }, RedProtect.get().getConfigManager().configRoot().region_settings.teleport_time, TimeUnit.SECONDS);
+            }, delay, TimeUnit.SECONDS);
         } else {
             RedProtect.get().getLanguageManager().sendMessage(p, "cmdmanager.region.tpneedwait");
         }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37253454/147421659-6052bbcf-b30d-4442-8a4e-c458d634fd24.png)

If the player doesn't need to wait to teleport, it's not necessary to send this message, and it saves system resources since no task is created in the scheduler.