### PR TITLE
Fix addblock subcommand

### DIFF
--- a/RedProtect-Spigot/pom.xml
+++ b/RedProtect-Spigot/pom.xml
@@ -302,7 +302,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.1-SNAPSHOT</version>
+                <version>3.4.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/commands/SubCommands/RegionHandlers/AddBlockCommand.java
+++ b/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/commands/SubCommands/RegionHandlers/AddBlockCommand.java
@@ -50,7 +50,7 @@ public class AddBlockCommand implements SubCommand {
 
             int blocks;
             try {
-                blocks = Integer.getInteger(args[1]);
+                blocks = Integer.parseInt(args[1]);
             } catch (Exception ex) {
                 RedProtect.get().getLanguageManager().sendMessage(sender, "cmdmanager.region.invalid.number");
                 return true;


### PR DESCRIPTION
I wanted a way to manually add claim blocks to a player (a bit like griefprevention does) but couldn't find anything in the docs.
Then I found this addblock subcommand in the code but it wasn't working when reading the block number.

Should be fixed now, but I would like to be able to use these extra blocks without enabling timed given claim blocks.