### PR TITLE
fix added players are displayed in lowercase

### DIFF
--- a/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/Region.java
+++ b/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/Region.java
@@ -473,7 +473,7 @@ public class Region extends CoreRegion {
      */
     public void addLeader(String uuid) {
         setToSave(true);
-        String name = RedProtect.get().getUtil().UUIDtoPlayer(uuid).toLowerCase();
+        String name = RedProtect.get().getUtil().UUIDtoPlayer(uuid);
         PlayerRegion pInfo = new PlayerRegion(RedProtect.get().getUtil().PlayerToUUID(uuid), name);
 
         this.members.removeIf(m -> m.getUUID().equalsIgnoreCase(uuid) || m.getPlayerName().equalsIgnoreCase(uuid));
@@ -492,7 +492,7 @@ public class Region extends CoreRegion {
      */
     public void addMember(String uuid) {
         setToSave(true);
-        String name = RedProtect.get().getUtil().UUIDtoPlayer(uuid).toLowerCase();
+        String name = RedProtect.get().getUtil().UUIDtoPlayer(uuid);
         PlayerRegion pInfo = new PlayerRegion(RedProtect.get().getUtil().PlayerToUUID(uuid), name);
 
         this.admins.removeIf(m -> m.getUUID().equalsIgnoreCase(uuid) || m.getPlayerName().equalsIgnoreCase(uuid));
@@ -511,7 +511,7 @@ public class Region extends CoreRegion {
      */
     public void addAdmin(String uuid) {
         setToSave(true);
-        String name = RedProtect.get().getUtil().UUIDtoPlayer(uuid).toLowerCase();
+        String name = RedProtect.get().getUtil().UUIDtoPlayer(uuid);
         PlayerRegion pInfo = new PlayerRegion(RedProtect.get().getUtil().PlayerToUUID(uuid), name);
 
         this.members.removeIf(m -> m.getUUID().equalsIgnoreCase(uuid) || m.getPlayerName().equalsIgnoreCase(uuid));
@@ -547,7 +547,7 @@ public class Region extends CoreRegion {
      */
     public void removeAdmin(String uuid) {
         setToSave(true);
-        String name = RedProtect.get().getUtil().UUIDtoPlayer(uuid).toLowerCase();
+        String name = RedProtect.get().getUtil().UUIDtoPlayer(uuid);
         PlayerRegion pInfo = new PlayerRegion(RedProtect.get().getUtil().PlayerToUUID(uuid), name);
 
         this.leaders.removeIf(m -> m.getUUID().equalsIgnoreCase(uuid) || m.getPlayerName().equalsIgnoreCase(uuid));
@@ -566,7 +566,7 @@ public class Region extends CoreRegion {
      */
     public void removeLeader(String uuid) {
         setToSave(true);
-        String name = RedProtect.get().getUtil().UUIDtoPlayer(uuid).toLowerCase();
+        String name = RedProtect.get().getUtil().UUIDtoPlayer(uuid);
         PlayerRegion pInfo = new PlayerRegion(RedProtect.get().getUtil().PlayerToUUID(uuid), name);
 
         this.members.removeIf(m -> m.getUUID().equalsIgnoreCase(uuid) || m.getPlayerName().equalsIgnoreCase(uuid));


### PR DESCRIPTION
When initially creating a region, the player name is correctly capitalized.
However, when you use commands to add/remove members, admins, and leaders, the names are saved and displayed in lowercase.