### PR TITLE
Make redefine take old region blocks into account

### DIFF
--- a/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/actions/RedefineRegionBuilder.java
+++ b/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/actions/RedefineRegionBuilder.java
@@ -114,7 +114,7 @@ public class RedefineRegionBuilder extends RegionBuilder {
         int regionArea = RedProtect.get().getUtil().simuleTotalRegionSize(p.getUniqueId().toString(), newRegion);
         int actualArea = 0;
         if (regionArea > 0) {
-            actualArea = totalArea + regionArea;
+            actualArea = totalArea - old.getArea() + regionArea;
         }
         if (pLimit >= 0 && actualArea > pLimit && !areaUnlimited) {
             this.setError(p, RedProtect.get().getLanguageManager().get("regionbuilder.reach.limit"));

--- a/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/config/BlockConfig.java
+++ b/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/config/BlockConfig.java
@@ -101,7 +101,7 @@ public class BlockConfig {
                 result = diffSeconds;
             }
 
-            return result + added_blocks;
+            return result * this.blockCat.blocks_to_add + added_blocks;
         } else {
             addPlayer(player);
         }


### PR DESCRIPTION
This fixes redefine so that it can work while under the blocklimit.
For example, if block limit is 150 and player has a region with 100 area, if he tried to redefine his region to an area of 145 it would say an error like "exceeded block limit"
Now it allows to redefine to 145 or whatever as long as it is below the block limit

I also fixed an issue in the BlockConfig where it wasn't using the blocks_to_add for timed claim blocks.

And finally, I changed the /rp redefine command so that you don't need to specify the region name if you are inside the region. You can simply do /rp redefine, but /rp redefine [region name] still works.

I know it looks like a lot of changes on the RedefineCommand class but I only moved the code out of the if block and added the part of "if (args.length == 0)"

If you need me to change anything or if it is too many changes let me know.