### PR TITLE
fix to 1.20.6 build 60 or more

### DIFF
--- a/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/guis/FlagGui.java
+++ b/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/guis/FlagGui.java
@@ -210,7 +210,21 @@ public class FlagGui implements Listener {
                 return;
             }
 
-            if (event.getInventory().equals(this.player.getOpenInventory().getTopInventory())) {
+            /**
+             * paper on 1.20.6 build 60+ changed the API to be a interface only, so we can abstract InventoryView to get the class,
+             * as describe by Rumsfield here https://www.spigotmc.org/threads/inventoryview-changed-to-interface-backwards-compatibility.651754/#post-4747875
+             */
+            Inventory topInv;
+            try {
+                InventoryView inventoryView = this.player.getOpenInventory();
+                Method getTopInventory = inventoryView.getClass().getMethod("getTopInventory");
+                getTopInventory.setAccessible(true);
+                topInv = (Inventory) getTopInventory.invoke(inventoryView);
+            } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+
+            if (event.getInventory().equals(topInv)) {
                 event.setCancelled(true);
                 ItemStack item = event.getCurrentItem();
                 if (item != null && !item.equals(RedProtect.get().getConfigManager().getGuiSeparator()) && !item.getType().equals(Material.AIR) && event.getRawSlot() >= 0 && event.getRawSlot() <= this.size - 1) {
@@ -305,7 +319,7 @@ public class FlagGui implements Listener {
         for (Player player : Bukkit.getServer().getOnlinePlayers()) {
 
             /**
-             * paper on 1.20.6 build 60+ changed the API to be a interface only, so we can abstract getTopInventory to get the class,
+             * paper on 1.20.6 build 60+ changed the API to be a interface only, so we can abstract InventoryView to get the class,
              * as describe by Rumsfield here https://www.spigotmc.org/threads/inventoryview-changed-to-interface-backwards-compatibility.651754/#post-4747875
              */
             Inventory topInv;

--- a/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/guis/FlagGui.java
+++ b/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/guis/FlagGui.java
@@ -326,6 +326,7 @@ public class FlagGui implements Listener {
             try {
                 InventoryView inventoryView = player.getOpenInventory();
                 Method getTopInventory = inventoryView.getClass().getMethod("getTopInventory");
+                getTopInventory.setAccessible(true);
                 topInv = (Inventory) getTopInventory.invoke(inventoryView);
             } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
                 throw new RuntimeException(e);

--- a/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/guis/ItemFlagGui.java
+++ b/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/guis/ItemFlagGui.java
@@ -40,8 +40,11 @@ import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 
 public class ItemFlagGui implements Listener {
@@ -63,7 +66,22 @@ public class ItemFlagGui implements Listener {
 
     @EventHandler
     void onInventoryClose(InventoryCloseEvent event) {
-        if (!event.getView().getPlayer().equals(this.player)) {
+
+        /**
+         * paper on 1.20.6 build 60+ changed the API to be a interface only, so we can abstract InventoryView to get the class,
+         * as describe by Rumsfield here https://www.spigotmc.org/threads/inventoryview-changed-to-interface-backwards-compatibility.651754/#post-4747875
+         */
+        Player vPlayer;
+        try {
+            InventoryView inventoryView = this.player.getOpenInventory();
+            Method getPlayer = inventoryView.getClass().getMethod("getPlayer");
+            getPlayer.setAccessible(true);
+            vPlayer = (Player) getPlayer.invoke(inventoryView);
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+
+        if (!event.getView().getPlayer().equals(vPlayer)) {
             return;
         }
 

--- a/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/guis/MobFlagGui.java
+++ b/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/guis/MobFlagGui.java
@@ -141,9 +141,9 @@ public class MobFlagGui implements Listener {
         Player vPlayer;
         try {
             InventoryView inventoryView = this.player.getOpenInventory();
-            Method getTopInventory = inventoryView.getClass().getMethod("getPlayer");
-            getTopInventory.setAccessible(true);
-            vPlayer = (Player) getTopInventory.invoke(inventoryView);
+            Method getPlayer = inventoryView.getClass().getMethod("getPlayer");
+            getPlayer.setAccessible(true);
+            vPlayer = (Player) getPlayer.invoke(inventoryView);
         } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }

--- a/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/listeners/PlayerListener.java
+++ b/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/listeners/PlayerListener.java
@@ -61,10 +61,13 @@ import org.bukkit.event.player.*;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.event.world.PortalCreateEvent;
 import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -96,7 +99,23 @@ public class PlayerListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onCraftItem(PrepareItemCraftEvent e) {
-        if (e.getView().getPlayer() instanceof Player p) {
+
+         /**
+         * paper on 1.20.6 build 60+ changed the API to be a interface only, so we can abstract InventoryView to get the class,
+         * as describe by Rumsfield here https://www.spigotmc.org/threads/inventoryview-changed-to-interface-backwards-compatibility.651754/#post-4747875
+         */
+        HumanEntity vHuman;
+        try {
+            
+            InventoryView inventoryView = e.getView();
+            Method getPlayer = inventoryView.getClass().getMethod("getPlayer");
+            getPlayer.setAccessible(true);
+            vHuman = (HumanEntity) getPlayer.invoke(inventoryView);
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException ex) {
+            throw new RuntimeException(ex);
+        }
+        
+        if (vHuman instanceof Player p) {
 
             ItemStack result = e.getInventory().getResult();
 


### PR DESCRIPTION
Paper changed internals on build 60 or more, to appear more be like [1.21+](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/d01c70e93ea1018048a433717c46120eaaeda5ab#src%2Fmain%2Fjava%2Forg%2Fbukkit%2Fcraftbukkit%2Futil%2FCommodore.java)

Up to 1.20.6 build 60, this error occur when we open GUI

```
[08:09:03 ERROR]: Command exception: /rp flag
org.bukkit.command.CommandException: Unhandled exception executing command 'rp' in plugin RedProtect v8.1.3-SNAPSHOT
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:47) ~[paper-api-1.20.6-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.command.brigadier.bukkit.BukkitCommandNode$BukkitBrigCommand.run(BukkitCommandNode.java:91) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at com.mojang.brigadier.context.ContextChain.runExecutable(ContextChain.java:73) ~[brigadier-1.2.9.jar:?]
	at net.minecraft.commands.execution.tasks.ExecuteCommand.execute(ExecuteCommand.java:31) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.commands.execution.tasks.ExecuteCommand.execute(ExecuteCommand.java:19) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.commands.execution.UnboundEntryAction.lambda$bind$0(UnboundEntryAction.java:8) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.commands.execution.CommandQueueEntry.execute(CommandQueueEntry.java:5) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.commands.execution.ExecutionContext.runCommandQueue(ExecutionContext.java:103) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.commands.Commands.executeCommandInContext(Commands.java:448) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.commands.Commands.performCommand(Commands.java:355) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.commands.Commands.performCommand(Commands.java:342) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.commands.Commands.performCommand(Commands.java:337) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.performSignedChatCommand(ServerGamePacketListenerImpl.java:2253) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.lambda$handleSignedChatCommand$12(ServerGamePacketListenerImpl.java:2215) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:151) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1511) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:195) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:125) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1488) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1411) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:135) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1377) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1238) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:323) ~[paper-1.20.6.jar:1.20.6-151-a4f0f5c]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
Caused by: java.lang.IncompatibleClassChangeError: Found class org.bukkit.inventory.InventoryView, but interface was expected
	at RedProtect-8.1.3-SNAPSHOT-b451-Spigot.jar/br.net.fabiozumbi12.RedProtect.Bukkit.guis.FlagGui.open(FlagGui.java:302) ~[RedProtect-8.1.3-SNAPSHOT-b451-Spigot.jar:?]
	at RedProtect-8.1.3-SNAPSHOT-b451-Spigot.jar/br.net.fabiozumbi12.RedProtect.Bukkit.commands.SubCommands.RegionHandlers.FlagCommand.onCommand(FlagCommand.java:86) ~[RedProtect-8.1.3-SNAPSHOT-b451-Spigot.jar:?]
	at RedProtect-8.1.3-SNAPSHOT-b451-Spigot.jar/br.net.fabiozumbi12.RedProtect.Bukkit.commands.CommandHandler.onCommand(CommandHandler.java:354) ~[RedProtect-8.1.3-SNAPSHOT-b451-Spigot.jar:?]
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:45) ~[paper-api-1.20.6-R0.1-SNAPSHOT.jar:?]
	... 26 more
```

I use the [Rumsfield](https://www.spigotmc.org/threads/inventoryview-changed-to-interface-backwards-compatibility.651754/#post-4747875) idea to use reflection methods, to work on any version

tested on: 

1.20.6 build 32
1.20.6 build 151
1.21.3 build 81

This is my first PR here, so if you want any code pattern or change, please tell me