### PR TITLE
Fix lectern books being unreadable in protected regions

### DIFF
--- a/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/listeners/PlayerListener.java
+++ b/RedProtect-Spigot/src/main/java/br/net/fabiozumbi12/RedProtect/Bukkit/listeners/PlayerListener.java
@@ -45,6 +45,7 @@ import me.NoChance.PvPManager.PvPlayer;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
+import org.bukkit.block.data.type.Lectern;
 import org.bukkit.entity.*;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
@@ -343,6 +344,12 @@ public class PlayerListener implements Listener {
                             RedProtect.get().getLanguageManager().sendMessage(p, "playerlistener.region.cantuse");
                             event.setCancelled(true);
                         }
+                    } else if (b.getType().name().contains("LECTERN")) {
+                        // Reading is always allowed; adding a book to an empty lectern needs build permission
+                        if (b.getBlockData() instanceof Lectern lectern && !lectern.hasBook() && !r.canBuild(p)) {
+                            RedProtect.get().getLanguageManager().sendMessage(p, "playerlistener.region.cantinteract");
+                            event.setCancelled(true);
+                        }
                     } else if (b.getState() instanceof InventoryHolder ||
                             RedProtect.get().getConfigManager().configRoot().private_cat.allowed_blocks.stream().anyMatch(b.getType().name()::matches)) {
                         var open = cont.canOpen(b, p, true);
@@ -362,7 +369,6 @@ public class PlayerListener implements Listener {
                             RedProtect.get().getLanguageManager().sendMessage(p, "playerlistener.region.cantlever");
                             event.setCancelled(true);
                         }
-                    } else if (b.getType().name().contains("LECTERN")) { // Do nothing to allow read books
                     } else if (b.getType().name().contains("BUTTON")) {
                         if (!r.canButton(p)) {
                             RedProtect.get().getLanguageManager().sendMessage(p, "playerlistener.region.cantbutton");


### PR DESCRIPTION
The branch meant to always allow reading lecterns (`// Do nothing to allow read books`) is unreachable: `Lectern` implements `BlockInventoryHolder`, so lecterns hit the earlier `instanceof InventoryHolder` branch and get treated as containers. Reading is therefore gated by the `chest` flag, and with `chest: false` a non-member cannot read the book at all.

This moves the lectern check above the container branch. Placing a book on an empty lectern is also just a `PlayerInteractEvent` and is currently blocked only by accident via `chest`, so the new branch allows the interaction unless the lectern is empty, where it requires `canBuild`. Taking a book is untouched (`PlayerTakeLecternBookEvent` in `Compat114`).

Side effect: private sign protection no longer applies to lecterns inside regions. Placing and taking are still gated by `canBuild`.